### PR TITLE
Add support for seeking and getting the length of the decoder's file

### DIFF
--- a/miniaudio/examples/playback-decoder.rs
+++ b/miniaudio/examples/playback-decoder.rs
@@ -1,7 +1,10 @@
 use miniaudio::{Decoder, Device, DeviceConfig, DeviceType};
+use std::sync::{Arc, Mutex};
 
 pub fn main() {
-    let mut decoder = Decoder::from_file("miniaudio/examples/assets/exit.wav", None).unwrap();
+    let decoder = Decoder::from_file("miniaudio/examples/assets/exit.wav", None).unwrap();
+    println!("Input file length (secs): {:?}", decoder.length());
+
     let mut config = DeviceConfig::new(DeviceType::Playback);
     config.playback_mut().set_format(decoder.output_format());
     config
@@ -9,8 +12,11 @@ pub fn main() {
         .set_channels(decoder.output_channels());
     config.set_sample_rate(decoder.output_sample_rate());
 
+    // Wrap decoder in Arc/Mutex so we can also use it for seeking later in the code
+    let decoder = Arc::new(Mutex::new(decoder));
+    let callback_decoder = decoder.clone();
     config.set_data_callback(move |_device, output, _frames| {
-        decoder.read_pcm_frames(output);
+        callback_decoder.lock().unwrap().read_pcm_frames(output);
     });
 
     config.set_stop_callback(|_device| {
@@ -21,7 +27,15 @@ pub fn main() {
     device.start().expect("failed to start device");
 
     println!("Device Backend: {:?}", device.context().backend());
+    print!("Press ENTER/RETURN to play again...");
     wait_for_enter();
+
+    if !decoder.lock().unwrap().seek_to_secs(0.0) {
+        println!("Unable to seek");
+    }
+    print!("Press ENTER/RETURN to exit...");
+    wait_for_enter();
+
     println!("Shutting Down...");
 }
 
@@ -29,7 +43,6 @@ pub fn main() {
 fn wait_for_enter() {
     use std::io::Write;
 
-    print!("Press ENTER/RETURN to exit...");
     // Make sure the line above is displayed:
     std::io::stdout().flush().expect("failed to flush stdout");
     // Just read some random line off of stdin and discard it:


### PR DESCRIPTION
This PR adds support for seeking in the decoder's stream, both on frame level and on (fractional) seconds level.

The example `playback-decoder` is adjusted so it plays the file twice, showing that seeking works.