### PR TITLE
Added thiserror dependency and changed the error type to use it

### DIFF
--- a/miniaudio/src/base.rs
+++ b/miniaudio/src/base.rs
@@ -277,6 +277,8 @@ impl std::fmt::Debug for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Channel {


### PR DESCRIPTION
Following up on #49, I made a few quick changes to `miniaudio::Error` to make it use thiserror and removed some now-redundant code.

Is this okay? I could refactor it into a manually implemented version without thiserror if the extra dependency is a no-no, I only used it because it's what I know and I like how the message is coupled with the error.