### PR TITLE
Added std::error::Error impl for error type

### DIFF
--- a/miniaudio/src/base.rs
+++ b/miniaudio/src/base.rs
@@ -277,6 +277,8 @@ impl std::fmt::Debug for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Channel {


### PR DESCRIPTION
Continuing from #50 and #49 (I didn't know renaming the branch in magit would close the PR).

Implementing `std::error::Error` is much simpler than I thought :)