### PR TITLE
Update target checks to support cross-compilation

### DIFF
--- a/miniaudio-sys/build.rs
+++ b/miniaudio-sys/build.rs
@@ -265,20 +265,26 @@ fn emit_supported_features() {
         }
     };
 
-    let ma_macos = cfg!(target_os = "macos");
-    let ma_ios = cfg!(target_os = "ios");
+    // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
+    let target_os =
+        std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set by cargo.");
+    let target_family =
+        std::env::var("CARGO_CFG_TARGET_FAMILY").expect("CARGO_CFG_TARGET_FAMILY is set by cargo.");
+
+    let ma_macos = target_os == "macos";
+    let ma_ios = target_os == "ios";
     let ma_apple = ma_macos | ma_ios;
-    let ma_win32 = cfg!(target_family = "windows");
+    let ma_win32 = target_family == "windows";
     let ma_win32_desktop = ma_win32; // FIXME for now I just assume they are the same.
-    let ma_unix = cfg!(target_family = "unix") && !ma_apple; // MacOS/iOS does not define __unix__ so doesn't define MA_UNIX in miniaudio.
-    let ma_android = cfg!(target_os = "android");
-    let ma_linux = ma_android | cfg!(target_os = "linux");
-    let ma_openbsd = cfg!(target_os = "openbsd");
-    let ma_freebsd = cfg!(target_os = "freebsd");
-    let ma_netbsd = cfg!(target_os = "netbsd");
-    let ma_dragonfly = cfg!(target_os = "dragonfly");
+    let ma_unix = target_family == "unix" && !ma_apple; // MacOS/iOS does not define __unix__ so doesn't define MA_UNIX in miniaudio.
+    let ma_android = target_os == "android";
+    let ma_linux = ma_android | (target_os == "linux");
+    let ma_openbsd = target_os == "openbsd";
+    let ma_freebsd = target_os == "freebsd";
+    let ma_netbsd = target_os == "netbsd";
+    let ma_dragonfly = target_os == "dragonfly";
     let ma_bsd = ma_openbsd | ma_freebsd | ma_netbsd | ma_dragonfly;
-    let ma_emscripten = cfg!(target_os = "emscripten");
+    let ma_emscripten = target_os == "emscripten";
 
     // #FIXME This is probably not correct but it's not a big deal atm.
     let ma_posix = !ma_win32;


### PR DESCRIPTION
Currently miniaudio-sys/build.rs uses the `cfg!` macro to determine the platform flags, but it seems like those values are not accurate for `build.rs` scripts. I think it's' implied by [this part of the Cargo docs](https://doc.rust-lang.org/cargo/reference/environment-variables.html):

> Cargo sets several environment variables when build scripts are run. Because these variables are not yet set when the build script is compiled, the above example using env! won't work and instead you'll need to retrieve the values when the build script is run:

This PR swaps the `cfg!` macro for the environment variables mentioned in the book. In my project, I encountered this when trying to cross-compile for wasm32 from macOS. Before the change, setting `--target` would have no effect on the miniaudio flags: I would still see `cargo:rustc-cfg=feature="ma-enable-coreaudio"` in the build log for instance. Now, when I target wasm32/emscripten, I see that the `-webaudio` is enabled and `-coreaudio` is not.

I see that you have a CI GitHub workflow, but please let me know if there's any other testing you'd like to see. I lifted the implementation from https://github.com/paritytech/rust-snappy/blob/1195dfa43e1e9b69464d5105d65ceea2619331c7/snappy-sys/build.rs#L26-L28

Fixes #39.