### PR TITLE
Update bindgen dependency to 0.59.2/newest.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,8 @@ jobs:
         
         - name: Get Tag
           run: |
-              echo "::set-env name=PUBLISH_TAG::${GITHUB_REF#refs/tags/}"
+              # echo "::set-env name=PUBLISH_TAG::${GITHUB_REF#refs/tags/}"
+              echo "PUBLISH_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
               echo "Publishing tag ${{ env.PUBLISH_TAG }}"
 
         # Display Tool Versions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Mini Audio Rust Bindings
 ===
 
+_Note:_ The upstream version is is archived. I currently don't use this anymore, but will do an update now and then. Most of it is untested.
+
 [![Build Status](https://github.com/ExPixel/miniaudio-rs/workflows/CI/badge.svg)](https://github.com/ExPixel/miniaudio-rs/actions?query=workflow%3ACI)
 [![crates.io](https://img.shields.io/crates/v/miniaudio.svg?color=orange)](https://crates.io/crates/miniaudio)
 [![docs.rs](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.rs/miniaudio)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Mini Audio Rust Bindings
 ===
 
-_Note:_ The upstream version is is archived. I currently don't use this anymore, but will do an update now and then. Most of it is untested.
+*Note:*
+The upstream version is is archived. I currently don't use this anymore, but will do an update now and then. Most of it is untested.
 
 [![Build Status](https://github.com/ExPixel/miniaudio-rs/workflows/CI/badge.svg)](https://github.com/ExPixel/miniaudio-rs/actions?query=workflow%3ACI)
 [![crates.io](https://img.shields.io/crates/v/miniaudio.svg?color=orange)](https://crates.io/crates/miniaudio)

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -73,4 +73,4 @@ bitflags = "1.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = { version = "0.54", default-features = false, features = ["runtime"], optional = true }
+bindgen = { version = "0.59.2", default-features = false, features = ["runtime"], optional = true }

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-ep-miniaudio-sys"
-version = "2.6.0"
+version = "2.6.1"
 authors = ["ExPixel <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Raw bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -69,8 +69,8 @@ ma-debug-output = []
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.3.2"
+bitflags = "2.4.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = { version = "0.63.0", default-features = false, features = ["runtime"], optional = true }
+bindgen = { version = "0.69.4", default-features = false, features = ["runtime"], optional = true }

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ep-miniaudio-sys"
+name = "om-fork-ep-miniaudio-sys"
 version = "2.5.0"
-authors = ["ExPixel <adolphc@outlook.com>"]
+authors = ["ExPixel <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
-description = "Raw bindings to the miniaudio C library."
+description = "Raw bindings to the miniaudio C library. Fork until upstream is updated!"
 documentation = "https://docs.rs/ep-miniaudio-sys"
-repository = "https://github.com/ExPixel/miniaudio-rs"
-homepage = "https://github.com/ExPixel/miniaudio-rs"
+repository = "https://github.com/andreasOM/miniaudio-rs"
+homepage = "https://github.com/andreasOM/miniaudio-rs"
 license = "MIT"
 keywords = ["audio", "miniaudio", "sound", "pcm"]
 publish = true

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-ep-miniaudio-sys"
-version = "2.6.0-dev"
+version = "2.6.0"
 authors = ["ExPixel <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Raw bindings to the miniaudio C library. Fork until upstream is updated!"

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ep-miniaudio-sys"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["ExPixel <adolphc@outlook.com>"]
 edition = "2018"
 description = "Raw bindings to the miniaudio C library."

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-ep-miniaudio-sys"
-version = "2.5.0"
+version = "2.6.0-dev"
 authors = ["ExPixel <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Raw bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -69,7 +69,7 @@ ma-debug-output = []
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.2"
+bitflags = "1.3.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -73,4 +73,4 @@ bitflags = "1.3.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = { version = "0.59.2", default-features = false, features = ["runtime"], optional = true }
+bindgen = { version = "0.63.0", default-features = false, features = ["runtime"], optional = true }

--- a/miniaudio-sys/Cargo.toml
+++ b/miniaudio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-ep-miniaudio-sys"
-version = "2.6.1"
+version = "2.6.2"
 authors = ["ExPixel <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Raw bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -69,8 +69,8 @@ ma-debug-output = []
 
 [dependencies]
 libc = "0.2"
-bitflags = "2.4.2"
+bitflags = "2.8.0"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = { version = "0.69.4", default-features = false, features = ["runtime"], optional = true }
+bindgen = { version = "0.71.1", default-features = false, features = ["runtime"], optional = true }

--- a/miniaudio-sys/README.md
+++ b/miniaudio-sys/README.md
@@ -1,0 +1,5 @@
+# om-ep-miniaudio-sys
+
+*Note:*
+The upstream version is currently broken due to an outdated cbindgen dependency.
+This is a workaround until upstream is fixed. A pull request has been made.

--- a/miniaudio-sys/README.md
+++ b/miniaudio-sys/README.md
@@ -1,5 +1,4 @@
 # om-ep-miniaudio-sys
 
 *Note:*
-The upstream version is currently broken due to an outdated cbindgen dependency.
-This is a workaround until upstream is fixed. A pull request has been made.
+The upstream version is is archived. I currently don't use this anymore, but will do an update now and then. Most of it is untested.

--- a/miniaudio-sys/build.rs
+++ b/miniaudio-sys/build.rs
@@ -97,9 +97,9 @@ fn generate_bindings() {
 
     let bindings = bindgen::Builder::default()
         // Make sure to only whitelist miniaudio's API.
-        .whitelist_type("ma_.*")
-        .whitelist_function("ma_.*")
-        .whitelist_var("(ma|MA)_.*")
+        .allowlist_type("ma_.*")
+        .allowlist_function("ma_.*")
+        .allowlist_var("(ma|MA)_.*")
         // We just use one big generated header created by concatenating what we need.
         .header(header)
         .size_t_is_usize(true)

--- a/miniaudio-sys/build.rs
+++ b/miniaudio-sys/build.rs
@@ -96,7 +96,7 @@ fn generate_bindings() {
     };
 
     let bindings = bindgen::Builder::default()
-        // Make sure to only whitelist miniaudio's API.
+        // Make sure to only allowlist miniaudio's API.
         .allowlist_type("ma_.*")
         .allowlist_function("ma_.*")
         .allowlist_var("(ma|MA)_.*")

--- a/miniaudio-sys/build.rs
+++ b/miniaudio-sys/build.rs
@@ -209,10 +209,10 @@ fn apply_definitions<F: FnMut(&str, &str)>(mut define: F) {
     }
 
     let mut log_level: Option<&'static str> = None;
-    const LOG_LEVEL_VERBOSE: &'static str = "4";
-    const LOG_LEVEL_INFO: &'static str = "3";
-    const LOG_LEVEL_WARNING: &'static str = "2";
-    const LOG_LEVEL_ERROR: &'static str = "1";
+    const LOG_LEVEL_VERBOSE: &str = "4";
+    const LOG_LEVEL_INFO: &str = "3";
+    const LOG_LEVEL_WARNING: &str = "2";
+    const LOG_LEVEL_ERROR: &str = "1";
 
     if cfg!(feature = "ma-log-level-error") {
         log_level = Some(LOG_LEVEL_ERROR);

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-miniaudio"
-version = "0.12.0-dev"
+version = "0.12.0"
 authors = ["Adolph C. <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -62,5 +62,5 @@ ma-log-level-error = ["om-fork-ep-miniaudio-sys/ma-log-level-error"]
 ma-debug-output = ["om-fork-ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
-om-fork-ep-miniaudio-sys = { version = "2.6.0-dev", path = "../miniaudio-sys", default-features = false }
+om-fork-ep-miniaudio-sys = { version = "2.6.0", path = "../miniaudio-sys", default-features = false }
 bitflags = "1.3.2"

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniaudio"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Adolph C. <adolphc@outlook.com>"]
 edition = "2018"
 description = "Bindings to the miniaudio C library."
@@ -62,5 +62,5 @@ ma-log-level-error = ["ep-miniaudio-sys/ma-log-level-error"]
 ma-debug-output = ["ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
-ep-miniaudio-sys = { version = "2", path = "../miniaudio-sys", default-features = false }
+ep-miniaudio-sys = { version = "2.5", path = "../miniaudio-sys", default-features = false }
 bitflags = "1.2"

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "miniaudio"
+name = "om-fork-miniaudio"
 version = "0.11.0"
-authors = ["Adolph C. <adolphc@outlook.com>"]
+authors = ["Adolph C. <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
-description = "Bindings to the miniaudio C library."
+description = "Bindings to the miniaudio C library. Fork until upstream is updated!"
 documentation = "https://docs.rs/miniaudio"
-repository = "https://github.com/ExPixel/miniaudio-rs"
-homepage = "https://github.com/ExPixel/miniaudio-rs"
+repository = "https://github.com/andreasOM/miniaudio-rs"
+homepage = "https://github.com/andreasOM/miniaudio-rs"
 license = "MIT"
 keywords = ["audio", "miniaudio", "sound", "pcm"]
 readme = "README.md"
@@ -24,43 +24,43 @@ crate_type = ["lib"]
 
 [features]
 default = ["ma-log-level-error", "bindgen"]
-bindgen = ["ep-miniaudio-sys/bindgen"]
+bindgen = ["om-fork-ep-miniaudio-sys/bindgen"]
 
-ma-enable-vorbis = ["ep-miniaudio-sys/ma-enable-vorbis"]
+ma-enable-vorbis = ["om-fork-ep-miniaudio-sys/ma-enable-vorbis"]
 
-ma-no-flac = ["ep-miniaudio-sys/ma-no-flac"]
-ma-no-mp3 = ["ep-miniaudio-sys/ma-no-mp3"]
-ma-no-wav = ["ep-miniaudio-sys/ma-no-wav"]
+ma-no-flac = ["om-fork-ep-miniaudio-sys/ma-no-flac"]
+ma-no-mp3 = ["om-fork-ep-miniaudio-sys/ma-no-mp3"]
+ma-no-wav = ["om-fork-ep-miniaudio-sys/ma-no-wav"]
 
-ma-no-wasapi = ["ep-miniaudio-sys/ma-no-wasapi"]
-ma-no-dsound = ["ep-miniaudio-sys/ma-no-dsound"]
-ma-no-winmm = ["ep-miniaudio-sys/ma-no-winmm"]
-ma-no-alsa = ["ep-miniaudio-sys/ma-no-alsa"]
-ma-no-pulseaudio = ["ep-miniaudio-sys/ma-no-pulseaudio"]
-ma-no-jack = ["ep-miniaudio-sys/ma-no-jack"]
-ma-no-coreaudio = ["ep-miniaudio-sys/ma-no-coreaudio"]
-ma-no-sndio = ["ep-miniaudio-sys/ma-no-sndio"]
-ma-no-audio4 = ["ep-miniaudio-sys/ma-no-audio4"]
-ma-no-oss = ["ep-miniaudio-sys/ma-no-oss"]
-ma-no-aaudio = ["ep-miniaudio-sys/ma-no-aaudio"]
-ma-no-opensl = ["ep-miniaudio-sys/ma-no-opensl"]
-ma-no-webaudio = ["ep-miniaudio-sys/ma-no-webaudio"]
-ma-no-null = ["ep-miniaudio-sys/ma-no-null"]
-ma-no-decoding = ["ep-miniaudio-sys/ma-no-decoding"]
-ma-no-device-io = ["ep-miniaudio-sys/ma-no-device-io"]
-ma-no-stdio = ["ep-miniaudio-sys/ma-no-stdio"]
-ma-no-sse2 = ["ep-miniaudio-sys/ma-no-sse2"]
-ma-no-avx2 = ["ep-miniaudio-sys/ma-no-avx2"]
-ma-no-avx512 = ["ep-miniaudio-sys/ma-no-avx512"]
-ma-no-neon = ["ep-miniaudio-sys/ma-no-neon"]
+ma-no-wasapi = ["om-fork-ep-miniaudio-sys/ma-no-wasapi"]
+ma-no-dsound = ["om-fork-ep-miniaudio-sys/ma-no-dsound"]
+ma-no-winmm = ["om-fork-ep-miniaudio-sys/ma-no-winmm"]
+ma-no-alsa = ["om-fork-ep-miniaudio-sys/ma-no-alsa"]
+ma-no-pulseaudio = ["om-fork-ep-miniaudio-sys/ma-no-pulseaudio"]
+ma-no-jack = ["om-fork-ep-miniaudio-sys/ma-no-jack"]
+ma-no-coreaudio = ["om-fork-ep-miniaudio-sys/ma-no-coreaudio"]
+ma-no-sndio = ["om-fork-ep-miniaudio-sys/ma-no-sndio"]
+ma-no-audio4 = ["om-fork-ep-miniaudio-sys/ma-no-audio4"]
+ma-no-oss = ["om-fork-ep-miniaudio-sys/ma-no-oss"]
+ma-no-aaudio = ["om-fork-ep-miniaudio-sys/ma-no-aaudio"]
+ma-no-opensl = ["om-fork-ep-miniaudio-sys/ma-no-opensl"]
+ma-no-webaudio = ["om-fork-ep-miniaudio-sys/ma-no-webaudio"]
+ma-no-null = ["om-fork-ep-miniaudio-sys/ma-no-null"]
+ma-no-decoding = ["om-fork-ep-miniaudio-sys/ma-no-decoding"]
+ma-no-device-io = ["om-fork-ep-miniaudio-sys/ma-no-device-io"]
+ma-no-stdio = ["om-fork-ep-miniaudio-sys/ma-no-stdio"]
+ma-no-sse2 = ["om-fork-ep-miniaudio-sys/ma-no-sse2"]
+ma-no-avx2 = ["om-fork-ep-miniaudio-sys/ma-no-avx2"]
+ma-no-avx512 = ["om-fork-ep-miniaudio-sys/ma-no-avx512"]
+ma-no-neon = ["om-fork-ep-miniaudio-sys/ma-no-neon"]
 
-ma-log-level-verbose = ["ep-miniaudio-sys/ma-log-level-verbose"]
-ma-log-level-info = ["ep-miniaudio-sys/ma-log-level-info"]
-ma-log-level-warning = ["ep-miniaudio-sys/ma-log-level-warning"]
-ma-log-level-error = ["ep-miniaudio-sys/ma-log-level-error"]
+ma-log-level-verbose = ["om-fork-ep-miniaudio-sys/ma-log-level-verbose"]
+ma-log-level-info = ["om-fork-ep-miniaudio-sys/ma-log-level-info"]
+ma-log-level-warning = ["om-fork-ep-miniaudio-sys/ma-log-level-warning"]
+ma-log-level-error = ["om-fork-ep-miniaudio-sys/ma-log-level-error"]
 
-ma-debug-output = ["ep-miniaudio-sys/ma-debug-output"]
+ma-debug-output = ["om-fork-ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
-ep-miniaudio-sys = { version = "2.5", path = "../miniaudio-sys", default-features = false }
+om-fork-ep-miniaudio-sys = { version = "2.5", path = "../miniaudio-sys", default-features = false }
 bitflags = "1.2"

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-miniaudio"
-version = "0.11.0"
+version = "0.12.0-dev"
 authors = ["Adolph C. <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -63,4 +63,4 @@ ma-debug-output = ["om-fork-ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
 om-fork-ep-miniaudio-sys = { version = "2.5", path = "../miniaudio-sys", default-features = false }
-bitflags = "1.2"
+bitflags = "1.3.2"

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -62,5 +62,5 @@ ma-log-level-error = ["om-fork-ep-miniaudio-sys/ma-log-level-error"]
 ma-debug-output = ["om-fork-ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
-om-fork-ep-miniaudio-sys = { version = "2.5", path = "../miniaudio-sys", default-features = false }
+om-fork-ep-miniaudio-sys = { version = "2.6.0-dev", path = "../miniaudio-sys", default-features = false }
 bitflags = "1.3.2"

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-miniaudio"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Adolph C. <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -62,5 +62,6 @@ ma-log-level-error = ["om-fork-ep-miniaudio-sys/ma-log-level-error"]
 ma-debug-output = ["om-fork-ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
-om-fork-ep-miniaudio-sys = { version = "2.6.0", path = "../miniaudio-sys", default-features = false }
-bitflags = "1.3.2"
+om-fork-ep-miniaudio-sys = { version = "2.6.1", path = "../miniaudio-sys", default-features = false }
+bitflags = "2.4.2"
+

--- a/miniaudio/Cargo.toml
+++ b/miniaudio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "om-fork-miniaudio"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Adolph C. <adolphc@outlook.com>", "anti <andreas@omni-mad.com>"]
 edition = "2018"
 description = "Bindings to the miniaudio C library. Fork until upstream is updated!"
@@ -62,6 +62,6 @@ ma-log-level-error = ["om-fork-ep-miniaudio-sys/ma-log-level-error"]
 ma-debug-output = ["om-fork-ep-miniaudio-sys/ma-debug-output"]
 
 [dependencies]
-om-fork-ep-miniaudio-sys = { version = "2.6.1", path = "../miniaudio-sys", default-features = false }
-bitflags = "2.4.2"
+om-fork-ep-miniaudio-sys = { version = "2.6.2", path = "../miniaudio-sys", default-features = false }
+bitflags = "2.8.0"
 

--- a/miniaudio/README.md
+++ b/miniaudio/README.md
@@ -1,6 +1,11 @@
 Mini Audio Rust Bindings
 ===
 
+*Note:*
+The upstream version is currently broken due to an outdated cbindgen dependency.
+This is a workaround until upstream is fixed. A pull request has been made.
+
+
 [![Build Status](https://github.com/ExPixel/miniaudio-rs/workflows/CI/badge.svg)](https://github.com/ExPixel/miniaudio-rs/actions?query=workflow%3ACI)
 [![crates.io](https://img.shields.io/crates/v/miniaudio.svg?color=orange)](https://crates.io/crates/miniaudio)
 [![docs.rs](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.rs/miniaudio)

--- a/miniaudio/README.md
+++ b/miniaudio/README.md
@@ -2,9 +2,7 @@ Mini Audio Rust Bindings
 ===
 
 *Note:*
-The upstream version is currently broken due to an outdated cbindgen dependency.
-This is a workaround until upstream is fixed. A pull request has been made.
-
+The upstream version is is archived. I currently don't use this anymore, but will do an update now and then. Most of it is untested.
 
 [![Build Status](https://github.com/ExPixel/miniaudio-rs/workflows/CI/badge.svg)](https://github.com/ExPixel/miniaudio-rs/actions?query=workflow%3ACI)
 [![crates.io](https://img.shields.io/crates/v/miniaudio.svg?color=orange)](https://crates.io/crates/miniaudio)

--- a/miniaudio/src/device_io.rs
+++ b/miniaudio/src/device_io.rs
@@ -865,7 +865,7 @@ impl ContextConfigCoreAudio {
 
     #[inline]
     pub fn set_session_category_options(&mut self, options: IOSSessionCategoryOption) {
-        self.0.sessionCategoryOptions = options.bits as _;
+        self.0.sessionCategoryOptions = options.bits() as _;
     }
 }
 


### PR DESCRIPTION
Update the bindgen dependency to 0.59.2 to avoid conflicts with other packages.
Bumped the version numbers to allow pinning of previous versions.

I couldn't do a full test run on everything, but it worked for all my use cases.